### PR TITLE
Feature/grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,28 @@
+module.exports = function(grunt) {
+    grunt.initConfig({
+        browserify: {
+            dist: {
+                options: {
+                    transform: [
+                        ["babelify", { "presets": ["es2015"] }]
+                    ]
+                },
+                files: {
+                    "./dist/string-builder.js": ["./src/string-builder.js"]
+                }
+            }
+        },
+        watch: {
+            script: {
+                files: ["./src/*.js"],
+                tasks: ["browserify"]
+            }
+        }
+    });
+
+    grunt.loadNpmTasks("grunt-browserify");
+    grunt.loadNpmTasks("grunt-contrib-watch");
+    
+    grunt.registerTask("default", ["watch"]);
+    grunt.registerTask("build", ["browserify"]);
+};

--- a/dist/string-builder.js
+++ b/dist/string-builder.js
@@ -44,7 +44,7 @@ StringBuilder.prototype.cat = function () {
         var prefixes = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
 
         var length = prefixes.length;
-        for (var i = prefixes.length; i >= 0; i--) {
+        for (var i = 0; i < length; i++) {
             var prefix = prefixes[i];
             if (prefix === false) {
                 break;
@@ -163,4 +163,5 @@ StringBuilder.prototype.when = function (expression, thenArgs, otherwiseArgs) {
 
     return this.cat(expression ? thenArgs : otherwiseArgs);
 };
+
 },{}]},{},[1]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ns-string-builder",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "src/string-builder.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/string-builder.js",
   "scripts": {
     "test": "jshint src/string-builder.js && mocha",
-    "build": "babel src --presets babel-preset-es2015 --out-dir lib && browserify lib/string-builder.js -o dist/string-builder.js"
+    "build": "grunt build"
   },
   "repository": {
     "type": "git",
@@ -20,8 +20,12 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
+    "babelify": "^7.3.0",
     "browserify": "^13.1.1",
     "chai": "^3.5.0",
+    "grunt": "^1.0.1",
+    "grunt-browserify": "^5.0.0",
+    "grunt-contrib-watch": "^1.0.0",
     "jsdoc": "^3.4.3",
     "jshint": "^2.9.4",
     "jsonfile": "^2.4.0",


### PR DESCRIPTION
### Use grunt to compile es6 to es5 and create bundle for web

- Create a grunt task for build and watch:
  -Both task compiles code from es5 to es5 and use browserify to create bundle for web use